### PR TITLE
subtitle: dump DVB subtitle frames to /tmp/current_sub.png

### DIFF
--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -154,12 +154,16 @@ void eSubtitleWidget::setPage(const eDVBSubtitlePage &p)
 		ePtr<gPixmap> subtitleFrame = new gPixmap(eSize(p.m_display_size.width(), p.m_display_size.height()), 32, 0);
 		if (subtitleFrame)
 		{
-			gRegion clip(eRect(0, 0, p.m_display_size.width(), p.m_display_size.height()));
-			subtitleFrame->fill(clip, gRGB(0, 0, 0, 0));
+			eRect clipRect(eRect(0, 0, p.m_display_size.width(), p.m_display_size.height()));
+			ePtr<gDC> subtitleFrameDC = new gDC(subtitleFrame);
+			gPainter subtitlePainter(subtitleFrameDC, eRect());
+			subtitlePainter.resetClip(clipRect);
+			subtitlePainter.setBackgroundColor(gRGB(0, 0, 0, 0));
+			subtitlePainter.clear();
 			for (std::list<eDVBSubtitleRegion>::const_iterator it(m_dvb_page.m_regions.begin()); it != m_dvb_page.m_regions.end(); ++it)
 			{
 				if (it->m_pixmap)
-					subtitleFrame->blit(*it->m_pixmap, eRect(it->m_position, it->m_pixmap->size()), clip, 0, 0, gPixmap::blitAlphaBlend);
+					subtitlePainter.blit(it->m_pixmap, eRect(it->m_position, it->m_pixmap->size()), clipRect, gPainter::BT_ALPHABLEND);
 			}
 			savePNG("/tmp/current_sub.png", &*subtitleFrame);
 		}

--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -155,6 +155,7 @@ void eSubtitleWidget::setPage(const eDVBSubtitlePage &p)
 		if (subtitleFrame)
 		{
 			gRegion clip(eRect(0, 0, p.m_display_size.width(), p.m_display_size.height()));
+			subtitleFrame->fill(clip, gRGB(0, 0, 0, 0));
 			for (std::list<eDVBSubtitleRegion>::const_iterator it(m_dvb_page.m_regions.begin()); it != m_dvb_page.m_regions.end(); ++it)
 			{
 				if (it->m_pixmap)

--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -1,6 +1,8 @@
 #include <lib/gui/esubtitle.h>
 #include <lib/gdi/grc.h>
 #include <lib/gdi/font.h>
+#include <lib/gdi/epng.h>
+#include <lib/gdi/region.h>
 #include <lib/base/estring.h>
 #include <lib/gui/ewidgetdesktop.h>
 #include <lib/base/esettings.h>
@@ -146,6 +148,22 @@ void eSubtitleWidget::setPage(const eDVBSubtitlePage &p)
 		r.scale(size().width(), p.m_display_size.width(), size().height(), p.m_display_size.height());
 		m_visible_region |= r;
 	}
+
+	if (!m_dvb_page.m_regions.empty() && p.m_display_size.width() > 0 && p.m_display_size.height() > 0)
+	{
+		ePtr<gPixmap> subtitleFrame = new gPixmap(eSize(p.m_display_size.width(), p.m_display_size.height()), 32, 0);
+		if (subtitleFrame)
+		{
+			gRegion clip(eRect(0, 0, p.m_display_size.width(), p.m_display_size.height()));
+			for (std::list<eDVBSubtitleRegion>::const_iterator it(m_dvb_page.m_regions.begin()); it != m_dvb_page.m_regions.end(); ++it)
+			{
+				if (it->m_pixmap)
+					subtitleFrame->blit(*it->m_pixmap, eRect(it->m_position, it->m_pixmap->size()), clip, 0, 0, gPixmap::blitAlphaBlend);
+			}
+			savePNG("/tmp/current_sub.png", &*subtitleFrame);
+		}
+	}
+
 	m_dvb_page_ok = 1;
 	m_hide_subtitles_timer->start(7500, true);
 	invalidate(m_visible_region); // invalidate new regions


### PR DESCRIPTION
### Motivation

- Provide a simple way to inspect graphical DVB subtitle frames by writing each subtitle page/frame to a known PNG file for debugging and tooling.

### Description

- Added includes for `lib/gdi/epng.h` and `lib/gdi/region.h` and extended `eSubtitleWidget::setPage(const eDVBSubtitlePage&)` to assemble subtitle regions into a single ARGB `gPixmap` matching the DVB display size. 
- Each region's pixmap is blitted into the composed frame using a clipping `gRegion` and `gPixmap::blit` with `blitAlphaBlend`, and the resulting image is saved with `savePNG("/tmp/current_sub.png", ...)` when a non-empty DVB subtitle page is received. 
- The new behavior is guarded by checks for non-empty region lists and valid `m_display_size` to avoid unnecessary work or invalid images. 
- Change committed with message: `subtitle: dump DVB subtitle frames to /tmp/current_sub.png`.

### Testing

- Ran `git diff -- lib/gui/esubtitle.cpp` to inspect the change, which showed the new PNG dumping logic and succeeded. 
- Performed `git add` and `git commit -m "subtitle: dump DVB subtitle frames to /tmp/current_sub.png"`, which completed successfully. 
- No automated build or runtime tests were executed in this rollout, so compilation and runtime behavior on target hardware remain unverified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f829c28ff88326b74295040c787fe9)